### PR TITLE
Resume file watching automatically after restart

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2473,6 +2473,7 @@ dependencies = [
  "tauri-plugin-log",
  "tauri-plugin-opener",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tokio",
@@ -5205,6 +5206,22 @@ checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
 dependencies = [
  "tauri",
  "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,6 +49,7 @@ futures = "0.3"
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"
 tauri-plugin-autostart = "2"
+tauri-plugin-single-instance = "2"
 
 [dev-dependencies]
 tauri = { version = "2", features = ["test"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,7 +5,7 @@ use parking_lot::Mutex;
 use std::collections::VecDeque;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use sysinfo::{CpuRefreshKind, System};
 use tauri::menu::{Menu, MenuItem};
@@ -79,8 +79,17 @@ struct DeviceInfo {
 type WatcherState = Arc<Mutex<Option<RecommendedWatcher>>>;
 // Folder currently being watched, if any
 type WatchedFolderState = Arc<Mutex<Option<String>>>;
+// Bumped by every start/stop request so an in-flight start (whose initial scan
+// can take a long time on big folders) can detect it was superseded and abort
+// instead of undoing a newer stop or folder change
+type WatchGeneration = Arc<AtomicU64>;
 
 const WATCHED_FOLDER_STORE_KEY: &str = "watched_folder";
+
+enum WatchStartOutcome {
+    Started,
+    Superseded,
+}
 
 #[tauri::command]
 async fn start_watching(
@@ -90,17 +99,25 @@ async fn start_watching(
     upload_queue: tauri::State<'_, UploadQueue>,
     upload_config: tauri::State<'_, UploadConfigState>,
     watched_folder: tauri::State<'_, WatchedFolderState>,
+    generation: tauri::State<'_, WatchGeneration>,
 ) -> Result<String, String> {
-    start_watching_impl(
-        folder_path,
+    let expected_generation = generation.fetch_add(1, Ordering::SeqCst) + 1;
+    match start_watching_impl(
+        folder_path.clone(),
         &app_handle,
         watcher_state.inner(),
         upload_queue.inner(),
         upload_config.inner(),
         watched_folder.inner(),
-    )
+        generation.inner(),
+        expected_generation,
+    )? {
+        WatchStartOutcome::Started => Ok(format!("Started watching: {folder_path}")),
+        WatchStartOutcome::Superseded => Ok("Watch superseded by a newer request".to_string()),
+    }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn start_watching_impl(
     folder_path: String,
     app_handle: &AppHandle,
@@ -108,7 +125,9 @@ fn start_watching_impl(
     upload_queue: &UploadQueue,
     upload_config: &UploadConfigState,
     watched_folder: &WatchedFolderState,
-) -> Result<String, String> {
+    generation: &WatchGeneration,
+    expected_generation: u64,
+) -> Result<WatchStartOutcome, String> {
     // Stop any existing watcher
     {
         let mut watcher = watcher_state.lock();
@@ -184,20 +203,25 @@ fn start_watching_impl(
         .watch(Path::new(&folder_path), RecursiveMode::Recursive)
         .map_err(|e| format!("Failed to watch folder: {e}"))?;
 
-    // Store the watcher
+    // Install the watcher, record the watched folder in memory, and persist it
+    // so watching resumes automatically on the next launch (e.g. autostart
+    // after a reboot). All three happen under the watcher lock, after checking
+    // that no newer start/stop request arrived while the initial scan ran —
+    // otherwise a slow scan would silently undo the user's later action.
     {
-        let mut watcher_state = watcher_state.lock();
-        *watcher_state = Some(watcher);
+        let mut watcher_guard = watcher_state.lock();
+        if generation.load(Ordering::SeqCst) != expected_generation {
+            log::info!("Watch start for {folder_path} was superseded before it finished; discarding");
+            return Ok(WatchStartOutcome::Superseded);
+        }
+        *watcher_guard = Some(watcher);
+        *watched_folder.lock() = Some(folder_path.clone());
+        if let Ok(store) = app_handle.store(SETTINGS_STORE_FILENAME) {
+            store.set(WATCHED_FOLDER_STORE_KEY, serde_json::json!(folder_path));
+        }
     }
 
-    // Record the watched folder in memory and persist it so watching resumes
-    // automatically on the next launch (e.g. autostart after a reboot)
-    *watched_folder.lock() = Some(folder_path.clone());
-    if let Ok(store) = app_handle.store(SETTINGS_STORE_FILENAME) {
-        store.set(WATCHED_FOLDER_STORE_KEY, serde_json::json!(folder_path));
-    }
-
-    Ok(format!("Started watching: {folder_path}"))
+    Ok(WatchStartOutcome::Started)
 }
 
 fn capture_initial_contents(
@@ -248,8 +272,12 @@ fn capture_initial_contents(
 async fn stop_watching(
     watcher_state: tauri::State<'_, WatcherState>,
     watched_folder: tauri::State<'_, WatchedFolderState>,
+    generation: tauri::State<'_, WatchGeneration>,
     app_handle: AppHandle,
 ) -> Result<String, String> {
+    // Invalidate any in-flight start before clearing, so a start that is still
+    // scanning cannot re-install itself after this stop completes
+    generation.fetch_add(1, Ordering::SeqCst);
     {
         let mut watcher = watcher_state.lock();
         *watcher = None;
@@ -458,6 +486,7 @@ struct QuitFlag(AtomicBool);
 pub fn run() {
     let watcher_state: WatcherState = Arc::new(Mutex::new(None));
     let watched_folder_state: WatchedFolderState = Arc::new(Mutex::new(None));
+    let watch_generation: WatchGeneration = Arc::new(AtomicU64::new(0));
     let upload_queue: UploadQueue = Arc::new(Mutex::new(VecDeque::new()));
     let upload_config: UploadConfigState = Arc::new(Mutex::new(UploadConfig::default()));
     let upload_progress: UploadProgressState = Arc::new(Mutex::new(UploadProgress {
@@ -507,6 +536,7 @@ pub fn run() {
         .manage(QuitFlag(AtomicBool::new(false)))
         .manage(watcher_state.clone())
         .manage(watched_folder_state.clone())
+        .manage(watch_generation.clone())
         .manage(http_client.clone())
         .manage(upload_queue.clone())
         .manage(upload_config.clone())
@@ -590,6 +620,9 @@ pub fn run() {
                     let watched_folder_state = watched_folder_state.clone();
                     let upload_queue = upload_queue.clone();
                     let upload_config = upload_config.clone();
+                    let generation = watch_generation.clone();
+                    let expected_generation =
+                        watch_generation.fetch_add(1, Ordering::SeqCst) + 1;
                     tauri::async_runtime::spawn_blocking(move || {
                         match start_watching_impl(
                             folder.clone(),
@@ -598,15 +631,26 @@ pub fn run() {
                             &upload_queue,
                             &upload_config,
                             &watched_folder_state,
+                            &generation,
+                            expected_generation,
                         ) {
-                            Ok(_) => {
+                            Ok(WatchStartOutcome::Started) => {
                                 log::info!("Resumed watching {folder} after restart");
                                 let _ = app_handle.emit("watch_resumed", &folder);
                             }
+                            Ok(WatchStartOutcome::Superseded) => {
+                                log::info!(
+                                    "Resume of {folder} superseded by a user start/stop request"
+                                );
+                            }
                             Err(e) => {
                                 log::error!("Failed to resume watching {folder}: {e}");
-                                *watched_folder_state.lock() = None;
-                                let _ = app_handle.emit("watch_resume_failed", &folder);
+                                // Only roll back if no newer start/stop request
+                                // owns the watch state by now
+                                if generation.load(Ordering::SeqCst) == expected_generation {
+                                    *watched_folder_state.lock() = None;
+                                    let _ = app_handle.emit("watch_resume_failed", &folder);
+                                }
                             }
                         }
                     });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -606,6 +606,7 @@ pub fn run() {
                             Err(e) => {
                                 log::error!("Failed to resume watching {folder}: {e}");
                                 *watched_folder_state.lock() = None;
+                                let _ = app_handle.emit("watch_resume_failed", &folder);
                             }
                         }
                     });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -36,12 +36,14 @@ fn show_main_window(window: &WebviewWindow) {
 }
 
 mod upload;
+use tauri_plugin_store::StoreExt;
 use upload::{
     add_to_upload_queue_sync, add_to_upload_queue_with_event_type, clear_session_context,
     clear_upload_queue, get_org_members, get_queue_size, get_session_context, get_upload_config,
-    get_upload_progress, process_upload_queue, restore_session_context, set_session_context,
-    set_upload_config, trigger_manual_upload, SessionContext, SessionContextState, UploadConfig,
-    UploadConfigState, UploadProgress, UploadProgressState, UploadQueue,
+    get_upload_progress, process_upload_queue, restore_session_context, restore_upload_config,
+    set_session_context, set_upload_config, trigger_manual_upload, SessionContext,
+    SessionContextState, UploadConfig, UploadConfigState, UploadProgress, UploadProgressState,
+    UploadQueue, SETTINGS_STORE_FILENAME,
 };
 
 mod heartbeat;
@@ -75,6 +77,10 @@ struct DeviceInfo {
 
 // Global watcher state
 type WatcherState = Arc<Mutex<Option<RecommendedWatcher>>>;
+// Folder currently being watched, if any
+type WatchedFolderState = Arc<Mutex<Option<String>>>;
+
+const WATCHED_FOLDER_STORE_KEY: &str = "watched_folder";
 
 #[tauri::command]
 async fn start_watching(
@@ -83,6 +89,25 @@ async fn start_watching(
     watcher_state: tauri::State<'_, WatcherState>,
     upload_queue: tauri::State<'_, UploadQueue>,
     upload_config: tauri::State<'_, UploadConfigState>,
+    watched_folder: tauri::State<'_, WatchedFolderState>,
+) -> Result<String, String> {
+    start_watching_impl(
+        folder_path,
+        &app_handle,
+        watcher_state.inner(),
+        upload_queue.inner(),
+        upload_config.inner(),
+        watched_folder.inner(),
+    )
+}
+
+fn start_watching_impl(
+    folder_path: String,
+    app_handle: &AppHandle,
+    watcher_state: &WatcherState,
+    upload_queue: &UploadQueue,
+    upload_config: &UploadConfigState,
+    watched_folder: &WatchedFolderState,
 ) -> Result<String, String> {
     // Stop any existing watcher
     {
@@ -91,16 +116,11 @@ async fn start_watching(
     }
 
     // First, capture initial folder contents and optionally queue for upload
-    capture_initial_contents(
-        &folder_path,
-        &app_handle,
-        upload_queue.inner(),
-        upload_config.inner(),
-    )?;
+    capture_initial_contents(&folder_path, app_handle, upload_queue, upload_config)?;
 
     let app_handle_clone = app_handle.clone();
-    let upload_queue_clone = upload_queue.inner().clone();
-    let upload_config_clone = upload_config.inner().clone();
+    let upload_queue_clone = upload_queue.clone();
+    let upload_config_clone = upload_config.clone();
     let folder_path_clone = folder_path.clone();
 
     // Channel to move work off the watcher callback thread so it never blocks
@@ -170,6 +190,13 @@ async fn start_watching(
         *watcher_state = Some(watcher);
     }
 
+    // Record the watched folder in memory and persist it so watching resumes
+    // automatically on the next launch (e.g. autostart after a reboot)
+    *watched_folder.lock() = Some(folder_path.clone());
+    if let Ok(store) = app_handle.store(SETTINGS_STORE_FILENAME) {
+        store.set(WATCHED_FOLDER_STORE_KEY, serde_json::json!(folder_path));
+    }
+
     Ok(format!("Started watching: {folder_path}"))
 }
 
@@ -218,10 +245,30 @@ fn capture_initial_contents(
 }
 
 #[tauri::command]
-async fn stop_watching(watcher_state: tauri::State<'_, WatcherState>) -> Result<String, String> {
-    let mut watcher = watcher_state.lock();
-    *watcher = None;
+async fn stop_watching(
+    watcher_state: tauri::State<'_, WatcherState>,
+    watched_folder: tauri::State<'_, WatchedFolderState>,
+    app_handle: AppHandle,
+) -> Result<String, String> {
+    {
+        let mut watcher = watcher_state.lock();
+        *watcher = None;
+    }
+    *watched_folder.lock() = None;
+
+    // The user explicitly stopped watching, so don't resume on next launch
+    if let Ok(store) = app_handle.store(SETTINGS_STORE_FILENAME) {
+        let _ = store.delete(WATCHED_FOLDER_STORE_KEY);
+    }
+
     Ok("Stopped watching".to_string())
+}
+
+#[tauri::command]
+fn get_watched_folder(
+    watched_folder: tauri::State<'_, WatchedFolderState>,
+) -> Result<Option<String>, String> {
+    Ok(watched_folder.lock().clone())
 }
 
 fn get_device_id_path(app_handle: &AppHandle) -> Result<PathBuf, String> {
@@ -410,6 +457,7 @@ struct QuitFlag(AtomicBool);
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let watcher_state: WatcherState = Arc::new(Mutex::new(None));
+    let watched_folder_state: WatchedFolderState = Arc::new(Mutex::new(None));
     let upload_queue: UploadQueue = Arc::new(Mutex::new(VecDeque::new()));
     let upload_config: UploadConfigState = Arc::new(Mutex::new(UploadConfig::default()));
     let upload_progress: UploadProgressState = Arc::new(Mutex::new(UploadProgress {
@@ -430,7 +478,20 @@ pub fn run() {
         }));
     let heartbeat_task_state: HeartbeatTaskState = Arc::new(tokio::sync::Mutex::new(None));
 
-    let app = tauri::Builder::default()
+    let builder = tauri::Builder::default();
+
+    // A second launch (e.g. clicking the shortcut while the autostarted
+    // instance is running) focuses the existing window instead of spawning a
+    // duplicate watcher/uploader. Release-only so `pnpm tauri dev` can still
+    // run alongside the installed app.
+    #[cfg(not(debug_assertions))]
+    let builder = builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+        if let Some(window) = app.get_webview_window("main") {
+            show_main_window(&window);
+        }
+    }));
+
+    let app = builder
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,
             None,
@@ -444,7 +505,8 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .manage(QuitFlag(AtomicBool::new(false)))
-        .manage(watcher_state)
+        .manage(watcher_state.clone())
+        .manage(watched_folder_state.clone())
         .manage(http_client.clone())
         .manage(upload_queue.clone())
         .manage(upload_config.clone())
@@ -456,6 +518,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             start_watching,
             stop_watching,
+            get_watched_folder,
             get_device_info,
             get_upload_config,
             set_upload_config,
@@ -478,6 +541,12 @@ pub fn run() {
             let restored_ctx = restore_session_context(app.handle());
             *session_context.lock() = restored_ctx;
 
+            // Restore persisted upload config (ignored patterns, delays, etc.)
+            // so headless resume below runs with the user's saved settings
+            if let Some(cfg) = restore_upload_config(app.handle()) {
+                *upload_config.lock() = cfg;
+            }
+
             // Start the upload processor in the background
             let upload_queue_clone = upload_queue.clone();
             let upload_config_clone = upload_config.clone();
@@ -497,6 +566,55 @@ pub fn run() {
                 )
                 .await;
             });
+
+            // Resume watching the folder that was being watched when the app
+            // last ran (e.g. autostart after a reboot), so sync continues
+            // without user interaction. The initial scan re-checks every file
+            // against the server, which also picks up changes made while the
+            // app was not running.
+            let persisted_folder = app
+                .handle()
+                .store(SETTINGS_STORE_FILENAME)
+                .ok()
+                .and_then(|s| s.get(WATCHED_FOLDER_STORE_KEY))
+                .and_then(|v| v.as_str().map(String::from));
+
+            if let Some(folder) = persisted_folder {
+                if Path::new(&folder).is_dir() {
+                    // Publish the folder before the scan finishes so the
+                    // frontend sees it as watched as soon as the webview loads
+                    *watched_folder_state.lock() = Some(folder.clone());
+
+                    let app_handle = app.handle().clone();
+                    let watcher_state = watcher_state.clone();
+                    let watched_folder_state = watched_folder_state.clone();
+                    let upload_queue = upload_queue.clone();
+                    let upload_config = upload_config.clone();
+                    tauri::async_runtime::spawn_blocking(move || {
+                        match start_watching_impl(
+                            folder.clone(),
+                            &app_handle,
+                            &watcher_state,
+                            &upload_queue,
+                            &upload_config,
+                            &watched_folder_state,
+                        ) {
+                            Ok(_) => {
+                                log::info!("Resumed watching {folder} after restart");
+                                let _ = app_handle.emit("watch_resumed", &folder);
+                            }
+                            Err(e) => {
+                                log::error!("Failed to resume watching {folder}: {e}");
+                                *watched_folder_state.lock() = None;
+                            }
+                        }
+                    });
+                } else {
+                    // Keep the stored path so a temporarily unavailable folder
+                    // (e.g. an unmounted drive) is retried on the next launch
+                    log::warn!("Not resuming watch: folder does not exist: {folder}");
+                }
+            }
 
             // Build system tray
             let show_i = MenuItem::with_id(app, "show", "Show", true, None::<&str>)?;

--- a/src-tauri/src/upload.rs
+++ b/src-tauri/src/upload.rs
@@ -890,7 +890,13 @@ const UPLOAD_CONFIG_STORE_KEY: &str = "upload_config";
 pub fn restore_upload_config(app_handle: &AppHandle) -> Option<UploadConfig> {
     let store = app_handle.store(SETTINGS_STORE_FILENAME).ok()?;
     let value = store.get(UPLOAD_CONFIG_STORE_KEY)?;
-    let mut config: UploadConfig = serde_json::from_value(value.clone()).ok()?;
+    let mut config: UploadConfig = match serde_json::from_value(value.clone()) {
+        Ok(config) => config,
+        Err(e) => {
+            log::warn!("Failed to restore upload config, using defaults: {e}");
+            return None;
+        }
+    };
     config.server_url = UploadConfig::default().server_url;
     Some(config)
 }

--- a/src-tauri/src/upload.rs
+++ b/src-tauri/src/upload.rs
@@ -39,7 +39,7 @@ const STATUS_UPLOADED: &str = "uploaded";
 const STATUS_FAILED: &str = "failed";
 
 // Store filename constant
-const SETTINGS_STORE_FILENAME: &str = "settings.json";
+pub const SETTINGS_STORE_FILENAME: &str = "settings.json";
 
 // ── Data types ──────────────────────────────────────────────────────────
 
@@ -864,9 +864,31 @@ pub fn get_upload_config(
 pub fn set_upload_config(
     config: UploadConfig,
     upload_config: tauri::State<'_, UploadConfigState>,
+    app_handle: AppHandle,
 ) -> Result<String, String> {
-    *upload_config.lock() = config;
+    *upload_config.lock() = config.clone();
+
+    if let Ok(store) = app_handle.store(SETTINGS_STORE_FILENAME) {
+        store.set(
+            UPLOAD_CONFIG_STORE_KEY,
+            serde_json::to_value(&config).unwrap_or_default(),
+        );
+    }
+
     Ok("Upload configuration updated".to_string())
+}
+
+const UPLOAD_CONFIG_STORE_KEY: &str = "upload_config";
+
+/// Restore the upload config from the Tauri Store on startup. The server URL
+/// always comes from the build environment, not the store, so a config saved
+/// by a dev build can never point a production build at localhost.
+pub fn restore_upload_config(app_handle: &AppHandle) -> Option<UploadConfig> {
+    let store = app_handle.store(SETTINGS_STORE_FILENAME).ok()?;
+    let value = store.get(UPLOAD_CONFIG_STORE_KEY)?;
+    let mut config: UploadConfig = serde_json::from_value(value.clone()).ok()?;
+    config.server_url = UploadConfig::default().server_url;
+    Some(config)
 }
 
 #[tauri::command]

--- a/src-tauri/src/upload.rs
+++ b/src-tauri/src/upload.rs
@@ -43,7 +43,11 @@ pub const SETTINGS_STORE_FILENAME: &str = "settings.json";
 
 // ── Data types ──────────────────────────────────────────────────────────
 
+// serde(default) keeps a stored config readable when future versions add
+// fields: missing fields fall back to Default instead of failing the whole
+// deserialization and discarding the user's settings
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct UploadConfig {
     pub enabled: bool,
     pub server_url: String,

--- a/src-tauri/src/upload.rs
+++ b/src-tauri/src/upload.rs
@@ -869,10 +869,10 @@ pub fn set_upload_config(
     *upload_config.lock() = config.clone();
 
     if let Ok(store) = app_handle.store(SETTINGS_STORE_FILENAME) {
-        store.set(
-            UPLOAD_CONFIG_STORE_KEY,
-            serde_json::to_value(&config).unwrap_or_default(),
-        );
+        match serde_json::to_value(&config) {
+            Ok(value) => store.set(UPLOAD_CONFIG_STORE_KEY, value),
+            Err(e) => log::error!("Failed to serialize upload config for persistence: {e}"),
+        }
     }
 
     Ok("Upload configuration updated".to_string())

--- a/src/components/simple.tsx
+++ b/src/components/simple.tsx
@@ -191,6 +191,10 @@ export default function Simple() {
     const unlistenWatchResumed = listen("watch_resumed", (event) => {
       setSelectedFolder(event.payload as string);
     });
+    const unlistenWatchResumeFailed = listen("watch_resume_failed", (event) => {
+      setSelectedFolder("");
+      toast.error(`Could not resume watching ${event.payload as string}`);
+    });
     invoke<string | null>("get_watched_folder")
       .then((folder) => {
         if (folder) setSelectedFolder(folder);
@@ -218,6 +222,7 @@ export default function Simple() {
       unlistenHeartbeat.then((fn) => fn());
       unlistenUploadStatus.then((fn) => fn());
       unlistenWatchResumed.then((fn) => fn());
+      unlistenWatchResumeFailed.then((fn) => fn());
     };
   }, []);
 

--- a/src/components/simple.tsx
+++ b/src/components/simple.tsx
@@ -186,6 +186,17 @@ export default function Simple() {
       setHeartbeatStatus(event.payload);
     });
 
+    // The backend resumes watching on its own after a restart; reflect that
+    // in the UI whether it finished before or after this component mounted
+    const unlistenWatchResumed = listen("watch_resumed", (event) => {
+      setSelectedFolder(event.payload as string);
+    });
+    invoke<string | null>("get_watched_folder")
+      .then((folder) => {
+        if (folder) setSelectedFolder(folder);
+      })
+      .catch((err) => console.error("Failed to get watched folder:", err));
+
     // Listen for file upload status events
     const unlistenUploadStatus = listen("file_upload_status", (event) => {
       console.log("file_upload_status", event);
@@ -206,6 +217,7 @@ export default function Simple() {
       unlistenFileChange.then((fn) => fn());
       unlistenHeartbeat.then((fn) => fn());
       unlistenUploadStatus.then((fn) => fn());
+      unlistenWatchResumed.then((fn) => fn());
     };
   }, []);
 


### PR DESCRIPTION
## Summary

With autostart enabled (added in #22), the app now launches at login — but it forgot what it was doing before the restart. This PR makes sync continue across restarts with no user interaction:

- **Persist the watched folder** in the Tauri Store (`watched_folder` key) whenever watching starts; cleared only when the user explicitly hits Stop.
- **Resume on launch**: `setup()` restores the saved folder and restarts the watcher on a background thread. The existing initial-scan path re-checks every file against the server (CRC32C dedup), so files that changed *while the app was closed* get synced too — unchanged files are skipped server-side.
- **Persist upload config**: previously ignored patterns / delays / toggles silently reset to defaults on every app restart, which would make a headless resume run with the wrong settings. Now saved under `upload_config` and restored at startup. The server URL is deliberately always taken from the build env rather than the store, so a config written by a dev build can never point a production build at localhost.
- **UI sync**: new `get_watched_folder` command + `watch_resumed` event, so the frontend shows the watched folder whether the webview loads before or after the resume finishes.
- **Single instance (release builds only)**: with auto-resume, a second app instance would immediately start a duplicate watcher and double-upload every change, so `tauri-plugin-single-instance` now focuses the existing window instead. Gated out of debug builds so `pnpm tauri dev` still works alongside the installed app.

## Testing

Verified end-to-end on Windows with a debug build against the production backend:
- Seeded `watched_folder` in the store, launched the app with no UI interaction → log shows `Resumed watching <folder> after restart`, the initial scan queued and uploaded the folder's file, and heartbeat continued.
- Created a new file after resume → watcher picked it up and uploaded it within seconds.
- Folder-missing-at-startup path skips resume with a warning but keeps the stored path so a temporarily unmounted drive is retried next boot.
- `cargo check`, `cargo clippy`, and `tsc` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)