### PR TITLE
Abort superseded watch starts before they queue any uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "labric-sync",
   "private": true,
-  "version": "0.1.15",
+  "version": "0.1.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2445,7 +2445,7 @@ dependencies = [
 
 [[package]]
 name = "labric-sync"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "base64 0.21.7",
  "bytes",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "labric-sync"
-version = "0.1.15"
+version = "0.1.16"
 description = "Labric Sync desktop app"
 authors = ["Labric"]
 edition = "2021"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,9 +42,11 @@ use upload::{
     clear_upload_queue, get_org_members, get_queue_size, get_session_context, get_upload_config,
     get_upload_progress, process_upload_queue, restore_session_context, restore_upload_config,
     set_session_context, set_upload_config, trigger_manual_upload, SessionContext,
-    SessionContextState, UploadConfig, UploadConfigState, UploadProgress, UploadProgressState,
-    UploadQueue, SETTINGS_STORE_FILENAME,
+    SessionContextState, UploadProgress, UploadProgressState, SETTINGS_STORE_FILENAME,
 };
+// Public so integration tests can drive the watch lifecycle; not a real API
+#[doc(hidden)]
+pub use upload::{UploadConfig, UploadConfigState, UploadQueue};
 
 mod heartbeat;
 use heartbeat::{
@@ -76,17 +78,22 @@ struct DeviceInfo {
 }
 
 // Global watcher state
-type WatcherState = Arc<Mutex<Option<RecommendedWatcher>>>;
+#[doc(hidden)]
+pub type WatcherState = Arc<Mutex<Option<RecommendedWatcher>>>;
 // Folder currently being watched, if any
-type WatchedFolderState = Arc<Mutex<Option<String>>>;
+#[doc(hidden)]
+pub type WatchedFolderState = Arc<Mutex<Option<String>>>;
 // Bumped by every start/stop request so an in-flight start (whose initial scan
 // can take a long time on big folders) can detect it was superseded and abort
 // instead of undoing a newer stop or folder change
-type WatchGeneration = Arc<AtomicU64>;
+#[doc(hidden)]
+pub type WatchGeneration = Arc<AtomicU64>;
 
 const WATCHED_FOLDER_STORE_KEY: &str = "watched_folder";
 
-enum WatchStartOutcome {
+#[doc(hidden)]
+#[derive(Debug)]
+pub enum WatchStartOutcome {
     Started,
     Superseded,
 }
@@ -117,10 +124,12 @@ async fn start_watching(
     }
 }
 
+// Public (doc-hidden) so integration tests can exercise the supersede logic
+#[doc(hidden)]
 #[allow(clippy::too_many_arguments)]
-fn start_watching_impl(
+pub fn start_watching_impl<R: tauri::Runtime>(
     folder_path: String,
-    app_handle: &AppHandle,
+    app_handle: &AppHandle<R>,
     watcher_state: &WatcherState,
     upload_queue: &UploadQueue,
     upload_config: &UploadConfigState,
@@ -128,14 +137,29 @@ fn start_watching_impl(
     generation: &WatchGeneration,
     expected_generation: u64,
 ) -> Result<WatchStartOutcome, String> {
-    // Stop any existing watcher
+    let is_superseded = || generation.load(Ordering::SeqCst) != expected_generation;
+
+    // Stop any existing watcher — checked under the lock so a stale start can
+    // never tear down a watcher that a newer request has already installed
     {
         let mut watcher = watcher_state.lock();
+        if is_superseded() {
+            return Ok(WatchStartOutcome::Superseded);
+        }
         *watcher = None;
     }
 
-    // First, capture initial folder contents and optionally queue for upload
-    capture_initial_contents(&folder_path, app_handle, upload_queue, upload_config)?;
+    // Scan the folder without touching the upload queue. Enqueueing is
+    // deferred until after the commit point below, so a start that is
+    // superseded mid-scan (the user stopped or picked another folder) leaves
+    // no uploads behind.
+    let files = match scan_folder_contents(&folder_path, app_handle, &is_superseded)? {
+        Some(files) => files,
+        None => {
+            log::info!("Initial scan of {folder_path} superseded before it finished; discarding");
+            return Ok(WatchStartOutcome::Superseded);
+        }
+    };
 
     let app_handle_clone = app_handle.clone();
     let upload_queue_clone = upload_queue.clone();
@@ -151,8 +175,17 @@ fn start_watching_impl(
         let queue = upload_queue_clone.clone();
         let config = upload_config_clone.clone();
         let app = app_handle.clone();
+        let generation = generation.clone();
         tauri::async_runtime::spawn(async move {
             while let Some((file_path, base_path)) = watcher_rx.recv().await {
+                // Watcher events can race in around a stop or a newer start
+                // (the watcher briefly runs before the commit check below, and
+                // channel events may still be in flight when it is dropped).
+                // Once this watch is no longer the newest request, drop them
+                // instead of queueing uploads for a folder the user left.
+                if generation.load(Ordering::SeqCst) != expected_generation {
+                    break;
+                }
                 add_to_upload_queue_sync(file_path, base_path, &queue, &config, &app);
             }
         });
@@ -210,7 +243,7 @@ fn start_watching_impl(
     // otherwise a slow scan would silently undo the user's later action.
     {
         let mut watcher_guard = watcher_state.lock();
-        if generation.load(Ordering::SeqCst) != expected_generation {
+        if is_superseded() {
             log::info!("Watch start for {folder_path} was superseded before it finished; discarding");
             return Ok(WatchStartOutcome::Superseded);
         }
@@ -221,15 +254,33 @@ fn start_watching_impl(
         }
     }
 
+    // The watch is committed; now queue the scanned files for upload. A stop
+    // or newer start arriving mid-enqueue aborts the remainder, the same way
+    // it would have aborted the scan.
+    enqueue_scanned_files(
+        files,
+        &folder_path,
+        upload_queue,
+        upload_config,
+        app_handle,
+        &is_superseded,
+    );
+
     Ok(WatchStartOutcome::Started)
 }
 
-fn capture_initial_contents(
+/// Walk the folder depth-first, emitting `file_change` events for the UI, and
+/// collect the files found — without queueing anything for upload yet, so an
+/// aborted start has no upload side effects. Returns `Ok(None)` if a newer
+/// start/stop request arrived mid-walk (checked per entry, so a stop during a
+/// large scan takes effect almost immediately).
+#[doc(hidden)]
+pub fn scan_folder_contents<R: tauri::Runtime>(
     folder_path: &str,
-    app_handle: &AppHandle,
-    upload_queue: &UploadQueue,
-    upload_config: &UploadConfigState,
-) -> Result<(), String> {
+    app_handle: &AppHandle<R>,
+    is_superseded: &impl Fn() -> bool,
+) -> Result<Option<Vec<String>>, String> {
+    let mut files = Vec::new();
     let mut dirs_to_visit = vec![PathBuf::from(folder_path)];
 
     while let Some(dir) = dirs_to_visit.pop() {
@@ -237,6 +288,9 @@ fn capture_initial_contents(
             fs::read_dir(&dir).map_err(|e| format!("Failed to read directory {dir:?}: {e}"))?;
 
         for entry in entries.flatten() {
+            if is_superseded() {
+                return Ok(None);
+            }
             let path = entry.path();
             let file_change = FileChangeEvent {
                 path: path.to_string_lossy().to_string(),
@@ -253,19 +307,43 @@ fn capture_initial_contents(
                 upload::emit_file_upload_status(&relative_path, upload::STATUS_DIRECTORY, None, app_handle);
                 dirs_to_visit.push(path);
             } else {
-                add_to_upload_queue_with_event_type(
-                    path.to_string_lossy().to_string(),
-                    folder_path.to_string(),
-                    upload_queue,
-                    upload_config,
-                    EVENT_TYPE_INITIAL,
-                    app_handle,
-                );
+                files.push(path.to_string_lossy().to_string());
             }
         }
     }
 
-    Ok(())
+    Ok(Some(files))
+}
+
+/// Queue the files collected by the initial scan, aborting the remainder if a
+/// newer start/stop request arrives mid-way.
+#[doc(hidden)]
+pub fn enqueue_scanned_files<R: tauri::Runtime>(
+    files: Vec<String>,
+    folder_path: &str,
+    upload_queue: &UploadQueue,
+    upload_config: &UploadConfigState,
+    app_handle: &AppHandle<R>,
+    is_superseded: &impl Fn() -> bool,
+) {
+    let total = files.len();
+    for (queued, file) in files.into_iter().enumerate() {
+        if is_superseded() {
+            log::info!(
+                "Watch of {folder_path} superseded; skipped queueing {} of {total} scanned files",
+                total - queued
+            );
+            return;
+        }
+        add_to_upload_queue_with_event_type(
+            file,
+            folder_path.to_string(),
+            upload_queue,
+            upload_config,
+            EVENT_TYPE_INITIAL,
+            app_handle,
+        );
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/upload.rs
+++ b/src-tauri/src/upload.rs
@@ -8,7 +8,7 @@ use parking_lot::Mutex;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Runtime};
 use tauri_plugin_store::StoreExt;
 use tokio::sync::Semaphore;
 use tokio::time::sleep;
@@ -189,11 +189,11 @@ struct PreparedUpload {
 
 // ── Small helpers ───────────────────────────────────────────────────────
 
-pub fn emit_file_upload_status(
+pub fn emit_file_upload_status<R: Runtime>(
     relative_path: &str,
     status: &str,
     error: Option<String>,
-    app_handle: &AppHandle,
+    app_handle: &AppHandle<R>,
 ) {
     let upload_status = FileUploadStatus {
         relative_path: relative_path.to_string(),
@@ -273,12 +273,12 @@ fn get_auth_token(app_handle: &AppHandle) -> Result<Option<String>, String> {
 
 // ── Queue management ────────────────────────────────────────────────────
 
-pub fn add_to_upload_queue_sync(
+pub fn add_to_upload_queue_sync<R: Runtime>(
     file_path: String,
     base_path: String,
     upload_queue: &UploadQueue,
     upload_config: &UploadConfigState,
-    app_handle: &AppHandle,
+    app_handle: &AppHandle<R>,
 ) {
     add_to_upload_queue_with_event_type(
         file_path,
@@ -290,13 +290,13 @@ pub fn add_to_upload_queue_sync(
     );
 }
 
-pub fn add_to_upload_queue_with_event_type(
+pub fn add_to_upload_queue_with_event_type<R: Runtime>(
     file_path: String,
     base_path: String,
     upload_queue: &UploadQueue,
     upload_config: &UploadConfigState,
     event_type: &str,
-    app_handle: &AppHandle,
+    app_handle: &AppHandle<R>,
 ) {
     let config = upload_config.lock().clone();
     let relative_path = get_relative_path(&file_path, &base_path);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Labric Sync",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "identifier": "co.labric.sync",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tests/watch_supersede.rs
+++ b/src-tauri/tests/watch_supersede.rs
@@ -1,0 +1,383 @@
+//! Tests for the watch start/stop supersede logic: a start that is overtaken
+//! by a newer start/stop request must abort without queueing uploads or
+//! disturbing state owned by the newer request.
+//!
+//! These live in an integration test target (not `#[cfg(test)]` in lib.rs)
+//! because on Windows the test binary needs the Common Controls v6 manifest
+//! that build.rs injects via `rustc-link-arg-tests`, which cargo only applies
+//! to integration test targets.
+
+use std::collections::VecDeque;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use notify::{RecursiveMode, Watcher};
+use parking_lot::Mutex;
+use tauri::test::{mock_builder, mock_context, noop_assets, MockRuntime};
+use uuid::Uuid;
+
+use labric_sync_lib::{
+    enqueue_scanned_files, scan_folder_contents, start_watching_impl, UploadConfig,
+    UploadConfigState, UploadQueue, WatchGeneration, WatchStartOutcome, WatchedFolderState,
+    WatcherState,
+};
+
+fn mock_app() -> tauri::App<MockRuntime> {
+    mock_builder()
+        // start_watching_impl persists the watched folder via the store
+        // plugin; without it registered, app_handle.store() panics
+        .plugin(tauri_plugin_store::Builder::default().build())
+        .build(mock_context(noop_assets()))
+        .expect("failed to build mock app")
+}
+
+/// Temp directory that cleans up on drop, without adding a tempfile dep
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new() -> Self {
+        let dir = std::env::temp_dir().join(format!("labric-sync-test-{}", Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        TempDir(dir)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+
+    fn path_str(&self) -> String {
+        self.0.to_string_lossy().to_string()
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+/// root/a.txt, root/b.tmp (matches the default "*.tmp" ignore pattern),
+/// root/sub/c.txt
+fn fixture_folder() -> TempDir {
+    let dir = TempDir::new();
+    fs::write(dir.path().join("a.txt"), "a").unwrap();
+    fs::write(dir.path().join("b.tmp"), "b").unwrap();
+    fs::create_dir(dir.path().join("sub")).unwrap();
+    fs::write(dir.path().join("sub").join("c.txt"), "c").unwrap();
+    dir
+}
+
+fn empty_queue() -> UploadQueue {
+    Arc::new(Mutex::new(VecDeque::new()))
+}
+
+fn default_config() -> UploadConfigState {
+    Arc::new(Mutex::new(UploadConfig::default()))
+}
+
+/// Returns true (superseded) starting from the nth call
+fn superseded_after(n: usize) -> impl Fn() -> bool {
+    let calls = AtomicUsize::new(0);
+    move || calls.fetch_add(1, Ordering::SeqCst) + 1 >= n
+}
+
+fn queued_paths(queue: &UploadQueue) -> Vec<String> {
+    queue.lock().iter().map(|item| item.path.clone()).collect()
+}
+
+#[test]
+fn scan_collects_files_recursively_without_queueing() {
+    let app = mock_app();
+    let dir = fixture_folder();
+
+    let files = scan_folder_contents(&dir.path_str(), app.handle(), &|| false)
+        .expect("scan failed")
+        .expect("scan unexpectedly superseded");
+
+    let mut names: Vec<String> = files
+        .iter()
+        .map(|f| {
+            Path::new(f)
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .to_string()
+        })
+        .collect();
+    names.sort();
+    // The scan collects everything, including files the upload config would
+    // ignore -- filtering happens at enqueue time
+    assert_eq!(names, ["a.txt", "b.tmp", "c.txt"]);
+}
+
+#[test]
+fn scan_aborts_when_superseded_immediately() {
+    let app = mock_app();
+    let dir = fixture_folder();
+
+    let result =
+        scan_folder_contents(&dir.path_str(), app.handle(), &|| true).expect("scan failed");
+
+    assert!(result.is_none(), "superseded scan must return None");
+}
+
+#[test]
+fn scan_aborts_when_superseded_mid_walk() {
+    let app = mock_app();
+    let dir = fixture_folder();
+
+    let result = scan_folder_contents(&dir.path_str(), app.handle(), &superseded_after(2))
+        .expect("scan failed");
+
+    assert!(result.is_none(), "scan superseded mid-walk must return None");
+}
+
+#[test]
+fn enqueue_queues_files_and_respects_ignore_patterns() {
+    let app = mock_app();
+    let dir = fixture_folder();
+    let queue = empty_queue();
+    let config = default_config();
+
+    let files = scan_folder_contents(&dir.path_str(), app.handle(), &|| false)
+        .unwrap()
+        .unwrap();
+    enqueue_scanned_files(files, &dir.path_str(), &queue, &config, app.handle(), &|| {
+        false
+    });
+
+    let paths = queued_paths(&queue);
+    assert_eq!(paths.len(), 2, "expected a.txt and c.txt, got {paths:?}");
+    assert!(paths.iter().any(|p| p.ends_with("a.txt")));
+    assert!(paths.iter().any(|p| p.ends_with("c.txt")));
+    assert!(
+        !paths.iter().any(|p| p.ends_with("b.tmp")),
+        "*.tmp files must be filtered out at enqueue time"
+    );
+}
+
+#[test]
+fn enqueue_aborts_when_superseded_midway() {
+    let app = mock_app();
+    let dir = TempDir::new();
+    for i in 0..5 {
+        fs::write(dir.path().join(format!("f{i}.txt")), "x").unwrap();
+    }
+    let queue = empty_queue();
+    let config = default_config();
+
+    let files = scan_folder_contents(&dir.path_str(), app.handle(), &|| false)
+        .unwrap()
+        .unwrap();
+    assert_eq!(files.len(), 5);
+
+    // Superseded from the third check onward: two files get queued, the
+    // remaining three must not
+    enqueue_scanned_files(
+        files,
+        &dir.path_str(),
+        &queue,
+        &config,
+        app.handle(),
+        &superseded_after(3),
+    );
+
+    assert_eq!(queue.lock().len(), 2);
+}
+
+#[test]
+fn start_watching_impl_starts_queues_and_records_state() {
+    let app = mock_app();
+    let dir = fixture_folder();
+    let watcher_state: WatcherState = Arc::new(Mutex::new(None));
+    let watched_folder: WatchedFolderState = Arc::new(Mutex::new(None));
+    let generation: WatchGeneration = Arc::new(AtomicU64::new(0));
+    let queue = empty_queue();
+    let config = default_config();
+
+    let expected = generation.fetch_add(1, Ordering::SeqCst) + 1;
+    let outcome = start_watching_impl(
+        dir.path_str(),
+        app.handle(),
+        &watcher_state,
+        &queue,
+        &config,
+        &watched_folder,
+        &generation,
+        expected,
+    )
+    .expect("start failed");
+
+    assert!(matches!(outcome, WatchStartOutcome::Started));
+    assert!(watcher_state.lock().is_some(), "watcher must be installed");
+    assert_eq!(*watched_folder.lock(), Some(dir.path_str()));
+    assert_eq!(
+        queue.lock().len(),
+        2,
+        "a.txt and c.txt queued, b.tmp ignored"
+    );
+}
+
+#[test]
+fn stale_start_is_superseded_before_any_side_effects() {
+    let app = mock_app();
+    let watcher_state: WatcherState = Arc::new(Mutex::new(None));
+    let watched_folder: WatchedFolderState = Arc::new(Mutex::new(None));
+    let generation: WatchGeneration = Arc::new(AtomicU64::new(2));
+    let queue = empty_queue();
+    let config = default_config();
+
+    // The folder deliberately does not exist: if the stale start ever reached
+    // the scan, this would return Err instead of Superseded
+    let outcome = start_watching_impl(
+        "Z:\\does\\not\\exist".to_string(),
+        app.handle(),
+        &watcher_state,
+        &queue,
+        &config,
+        &watched_folder,
+        &generation,
+        1, // stale: current generation is 2
+    )
+    .expect("stale start must not error");
+
+    assert!(matches!(outcome, WatchStartOutcome::Superseded));
+    assert!(watcher_state.lock().is_none());
+    assert!(watched_folder.lock().is_none());
+    assert!(
+        queue.lock().is_empty(),
+        "superseded start must queue nothing"
+    );
+}
+
+#[test]
+fn stale_start_does_not_disturb_current_watcher() {
+    let app = mock_app();
+    let current_dir = fixture_folder();
+    let watcher_state: WatcherState = Arc::new(Mutex::new(None));
+    let watched_folder: WatchedFolderState = Arc::new(Mutex::new(Some(current_dir.path_str())));
+    let generation: WatchGeneration = Arc::new(AtomicU64::new(2));
+    let queue = empty_queue();
+    let config = default_config();
+
+    // Install a watcher owned by the current (generation 2) watch
+    let mut watcher = notify::recommended_watcher(|_| {}).unwrap();
+    watcher
+        .watch(current_dir.path(), RecursiveMode::Recursive)
+        .unwrap();
+    *watcher_state.lock() = Some(watcher);
+
+    let outcome = start_watching_impl(
+        "Z:\\does\\not\\exist".to_string(),
+        app.handle(),
+        &watcher_state,
+        &queue,
+        &config,
+        &watched_folder,
+        &generation,
+        1, // stale request racing against the installed generation-2 watch
+    )
+    .expect("stale start must not error");
+
+    assert!(matches!(outcome, WatchStartOutcome::Superseded));
+    assert!(
+        watcher_state.lock().is_some(),
+        "stale start must not tear down the newer watch's watcher"
+    );
+    assert_eq!(*watched_folder.lock(), Some(current_dir.path_str()));
+    assert!(queue.lock().is_empty());
+}
+
+#[test]
+fn start_superseded_by_stop_leaves_queue_empty_and_no_watcher() {
+    let app = mock_app();
+    let dir = fixture_folder();
+    let watcher_state: WatcherState = Arc::new(Mutex::new(None));
+    let watched_folder: WatchedFolderState = Arc::new(Mutex::new(None));
+    let generation: WatchGeneration = Arc::new(AtomicU64::new(0));
+    let queue = empty_queue();
+    let config = default_config();
+
+    let expected = generation.fetch_add(1, Ordering::SeqCst) + 1;
+    // Simulate stop_watching winning the race: its generation bump lands
+    // before this start makes any progress
+    generation.fetch_add(1, Ordering::SeqCst);
+
+    let outcome = start_watching_impl(
+        dir.path_str(),
+        app.handle(),
+        &watcher_state,
+        &queue,
+        &config,
+        &watched_folder,
+        &generation,
+        expected,
+    )
+    .expect("superseded start must not error");
+
+    assert!(matches!(outcome, WatchStartOutcome::Superseded));
+    assert!(watcher_state.lock().is_none());
+    assert!(watched_folder.lock().is_none());
+    assert!(
+        queue.lock().is_empty(),
+        "a start superseded by stop must not queue any uploads"
+    );
+}
+
+/// End-to-end race: a stop arrives while the start's initial scan is running.
+/// The scan observes the generation bump mid-walk, aborts, and leaves no
+/// uploads or watcher behind.
+#[test]
+fn stop_arriving_mid_scan_aborts_start_without_queueing() {
+    let app = mock_app();
+    let dir = fixture_folder();
+    let watcher_state: WatcherState = Arc::new(Mutex::new(None));
+    let watched_folder: WatchedFolderState = Arc::new(Mutex::new(None));
+    let generation: WatchGeneration = Arc::new(AtomicU64::new(0));
+    let queue = empty_queue();
+    let config = default_config();
+
+    let expected = generation.fetch_add(1, Ordering::SeqCst) + 1;
+
+    // Bump the generation from another thread shortly after the start begins,
+    // like stop_watching would. Whether the bump lands before, during, or
+    // after the scan, the outcome must be consistent: either the start
+    // committed fully before the stop (watcher installed, files queued) or it
+    // was superseded (nothing queued, no watcher).
+    let generation_for_stop = generation.clone();
+    let stopper = std::thread::spawn(move || {
+        generation_for_stop.fetch_add(1, Ordering::SeqCst);
+    });
+
+    let outcome = start_watching_impl(
+        dir.path_str(),
+        app.handle(),
+        &watcher_state,
+        &queue,
+        &config,
+        &watched_folder,
+        &generation,
+        expected,
+    )
+    .expect("start must not error");
+    stopper.join().unwrap();
+
+    match outcome {
+        WatchStartOutcome::Superseded => {
+            assert!(
+                queue.lock().is_empty(),
+                "superseded start must not queue uploads"
+            );
+            assert!(watcher_state.lock().is_none());
+            assert!(watched_folder.lock().is_none());
+        }
+        WatchStartOutcome::Started => {
+            // The start won the race and committed before the bump was
+            // observable at any check point; committed state must be complete
+            assert!(watcher_state.lock().is_some());
+            assert_eq!(*watched_folder.lock(), Some(dir.path_str()));
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Follow-up to the resume-watching PR. A `start_watching` that got superseded mid-scan (by `stop_watching` or a newer start) had already enqueued the entire folder into the upload queue — the generation check only prevented the watcher from installing, not the side effects. Worst case: a user picks a huge folder by mistake, hits stop during the initial scan, and the app uploads everything anyway. There was also a brief window where the new watcher was live before the commit check, so events for the abandoned folder could slip into the queue, and a theoretical race where a stale start could tear down a watcher a newer request had just installed.

## Fix

- **Collect-then-commit**: the initial scan now only collects file paths. Enqueueing happens after the commit point (watcher installed under the generation check), so a superseded start queues nothing.
- **Per-entry supersede check** in the scan, so a stop during a large scan takes effect almost immediately instead of after the full walk.
- **Generation-checked drain task**: watcher events that race in around a stop/newer start are dropped instead of queued.
- **Generation check before stopping the existing watcher** (under the watcher lock), closing the race where a stale start could destroy the winner's watcher.
- Enqueueing after commit also aborts mid-way if superseded.

## Tests

New `tests/watch_supersede.rs` (10 tests, all passing) driving the real `start_watching_impl` with Tauri's `MockRuntime`: normal start commits and queues (ignore patterns respected), stale starts abort with zero side effects and don't disturb the current watcher, stop-superseded starts leave the queue empty, plus a threaded race test. The touched functions are now generic over `tauri::Runtime` and exposed `#[doc(hidden)] pub` to make this possible.

Note: tests are an integration-test target rather than `#[cfg(test)]` unit tests because on Windows only integration test targets get the Common Controls v6 manifest from build.rs — unit test binaries crash at load with `STATUS_ENTRYPOINT_NOT_FOUND` (`rustc-link-arg-tests` doesn't apply to them).

`cargo test`, `cargo check`, and `cargo clippy --all-targets` are all clean.
