### PR TITLE
Replay pre-mount file events so resumed watches show existing files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ cargo clippy --manifest-path src-tauri/Cargo.toml   # Lint Rust code
 
 ## CI/CD
 
+- Every new PR must bump the version (patch bump unless told otherwise) in all three places: `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`
 - GitHub Actions on push to `main` builds for macOS (x86_64 + aarch64), Linux, Windows
 - Builds are code-signed (Apple notarization + DigiCert for Windows)
 - Auto-updates via Tauri updater plugin pulling from GitHub Releases

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "labric-sync",
   "private": true,
-  "version": "0.1.15",
+  "version": "0.1.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2445,7 +2445,7 @@ dependencies = [
 
 [[package]]
 name = "labric-sync"
-version = "0.1.15"
+version = "0.1.17"
 dependencies = [
  "base64 0.21.7",
  "bytes",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "labric-sync"
-version = "0.1.15"
+version = "0.1.17"
 description = "Labric Sync desktop app"
 authors = ["Labric"]
 edition = "2021"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,12 +42,15 @@ use upload::{
     clear_upload_queue, get_org_members, get_queue_size, get_session_context, get_upload_config,
     get_upload_progress, get_upload_status_backlog, process_upload_queue, restore_session_context,
     restore_upload_config, set_session_context, set_upload_config, trigger_manual_upload,
-    SessionContext, SessionContextState, UploadProgress, UploadProgressState, UploadStatusLog,
+    SessionContext, SessionContextState, UploadProgress, UploadProgressState,
     SETTINGS_STORE_FILENAME,
 };
 // Public so integration tests can drive the watch lifecycle; not a real API
 #[doc(hidden)]
-pub use upload::{UploadConfig, UploadConfigState, UploadQueue};
+pub use upload::{
+    emit_file_upload_status, FileUploadStatus, UploadConfig, UploadConfigState, UploadQueue,
+    UploadStatusLog, MAX_UPLOAD_STATUS_LOG,
+};
 
 mod heartbeat;
 use heartbeat::{
@@ -58,11 +61,12 @@ use heartbeat::{
 mod diagnostics;
 use diagnostics::run_network_diagnostics;
 
+#[doc(hidden)]
 #[derive(Clone, Serialize, Deserialize)]
-struct FileChangeEvent {
-    path: String,
-    event_type: String,
-    timestamp: u64,
+pub struct FileChangeEvent {
+    pub path: String,
+    pub event_type: String,
+    pub timestamp: u64,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -93,10 +97,12 @@ pub type WatchGeneration = Arc<AtomicU64>;
 // events emitted before the webview has registered listeners (e.g. the whole
 // initial scan of a watch resumed at startup), so the frontend replays this
 // backlog on mount via get_file_change_backlog.
-type FileChangeLog = Arc<Mutex<VecDeque<FileChangeEvent>>>;
+#[doc(hidden)]
+pub type FileChangeLog = Arc<Mutex<VecDeque<FileChangeEvent>>>;
 
 // Matches the frontend's file-change list cap
-const MAX_FILE_CHANGE_LOG: usize = 500;
+#[doc(hidden)]
+pub const MAX_FILE_CHANGE_LOG: usize = 500;
 
 fn record_and_emit_file_change<R: tauri::Runtime>(
     app_handle: &AppHandle<R>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,10 +40,10 @@ use tauri_plugin_store::StoreExt;
 use upload::{
     add_to_upload_queue_sync, add_to_upload_queue_with_event_type, clear_session_context,
     clear_upload_queue, get_org_members, get_queue_size, get_session_context, get_upload_config,
-    get_upload_progress, process_upload_queue, restore_session_context, restore_upload_config,
-    set_session_context, set_upload_config, trigger_manual_upload, SessionContext,
-    SessionContextState, UploadConfig, UploadConfigState, UploadProgress, UploadProgressState,
-    UploadQueue, SETTINGS_STORE_FILENAME,
+    get_upload_progress, get_upload_status_backlog, process_upload_queue, restore_session_context,
+    restore_upload_config, set_session_context, set_upload_config, trigger_manual_upload,
+    SessionContext, SessionContextState, UploadConfig, UploadConfigState, UploadProgress,
+    UploadProgressState, UploadQueue, UploadStatusLog, SETTINGS_STORE_FILENAME,
 };
 
 mod heartbeat;
@@ -83,6 +83,27 @@ type WatchedFolderState = Arc<Mutex<Option<String>>>;
 // can take a long time on big folders) can detect it was superseded and abort
 // instead of undoing a newer stop or folder change
 type WatchGeneration = Arc<AtomicU64>;
+// Recent file-change events, oldest first, one entry per path. Tauri drops
+// events emitted before the webview has registered listeners (e.g. the whole
+// initial scan of a watch resumed at startup), so the frontend replays this
+// backlog on mount via get_file_change_backlog.
+type FileChangeLog = Arc<Mutex<VecDeque<FileChangeEvent>>>;
+
+// Matches the frontend's file-change list cap
+const MAX_FILE_CHANGE_LOG: usize = 500;
+
+fn record_and_emit_file_change(app_handle: &AppHandle, event: &FileChangeEvent) {
+    if let Some(log) = app_handle.try_state::<FileChangeLog>() {
+        let mut log = log.lock();
+        // Keep only the latest event per path, mirroring the frontend list
+        log.retain(|e| e.path != event.path);
+        if log.len() >= MAX_FILE_CHANGE_LOG {
+            log.pop_front();
+        }
+        log.push_back(event.clone());
+    }
+    let _ = app_handle.emit("file_change", event);
+}
 
 const WATCHED_FOLDER_STORE_KEY: &str = "watched_folder";
 
@@ -132,6 +153,12 @@ fn start_watching_impl(
     {
         let mut watcher = watcher_state.lock();
         *watcher = None;
+    }
+
+    // Drop backlog entries from any previously watched folder, matching the
+    // frontend clearing its list when the watched folder changes
+    if let Some(log) = app_handle.try_state::<FileChangeLog>() {
+        log.lock().clear();
     }
 
     // First, capture initial folder contents and optionally queue for upload
@@ -187,7 +214,7 @@ fn start_watching_impl(
             };
 
             // Send to frontend immediately — never blocked by queue locks
-            let _ = app_handle_clone.emit("file_change", &file_change);
+            record_and_emit_file_change(&app_handle_clone, &file_change);
 
             // Queue for upload via channel (non-blocking send)
             if event_type == EVENT_TYPE_CREATED || event_type == EVENT_TYPE_MODIFIED {
@@ -246,7 +273,7 @@ fn capture_initial_contents(
                     .unwrap()
                     .as_secs(),
             };
-            let _ = app_handle.emit("file_change", &file_change);
+            record_and_emit_file_change(app_handle, &file_change);
 
             if path.is_dir() {
                 let relative_path = upload::get_relative_path(&path.to_string_lossy(), folder_path);
@@ -284,6 +311,11 @@ async fn stop_watching(
     }
     *watched_folder.lock() = None;
 
+    // Match the frontend, which clears its file list on stop
+    if let Some(log) = app_handle.try_state::<FileChangeLog>() {
+        log.lock().clear();
+    }
+
     // The user explicitly stopped watching, so don't resume on next launch
     if let Ok(store) = app_handle.store(SETTINGS_STORE_FILENAME) {
         let _ = store.delete(WATCHED_FOLDER_STORE_KEY);
@@ -297,6 +329,14 @@ fn get_watched_folder(
     watched_folder: tauri::State<'_, WatchedFolderState>,
 ) -> Result<Option<String>, String> {
     Ok(watched_folder.lock().clone())
+}
+
+#[tauri::command]
+fn get_file_change_backlog(
+    log: tauri::State<'_, FileChangeLog>,
+) -> Result<Vec<FileChangeEvent>, String> {
+    // Newest first, matching the frontend's display order
+    Ok(log.lock().iter().rev().cloned().collect())
 }
 
 fn get_device_id_path(app_handle: &AppHandle) -> Result<PathBuf, String> {
@@ -487,6 +527,8 @@ pub fn run() {
     let watcher_state: WatcherState = Arc::new(Mutex::new(None));
     let watched_folder_state: WatchedFolderState = Arc::new(Mutex::new(None));
     let watch_generation: WatchGeneration = Arc::new(AtomicU64::new(0));
+    let file_change_log: FileChangeLog = Arc::new(Mutex::new(VecDeque::new()));
+    let upload_status_log: UploadStatusLog = Arc::new(Mutex::new(Vec::new()));
     let upload_queue: UploadQueue = Arc::new(Mutex::new(VecDeque::new()));
     let upload_config: UploadConfigState = Arc::new(Mutex::new(UploadConfig::default()));
     let upload_progress: UploadProgressState = Arc::new(Mutex::new(UploadProgress {
@@ -537,6 +579,8 @@ pub fn run() {
         .manage(watcher_state.clone())
         .manage(watched_folder_state.clone())
         .manage(watch_generation.clone())
+        .manage(file_change_log.clone())
+        .manage(upload_status_log.clone())
         .manage(http_client.clone())
         .manage(upload_queue.clone())
         .manage(upload_config.clone())
@@ -549,6 +593,8 @@ pub fn run() {
             start_watching,
             stop_watching,
             get_watched_folder,
+            get_file_change_backlog,
+            get_upload_status_backlog,
             get_device_info,
             get_upload_config,
             set_upload_config,

--- a/src-tauri/src/upload.rs
+++ b/src-tauri/src/upload.rs
@@ -8,7 +8,7 @@ use parking_lot::Mutex;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_store::StoreExt;
 use tokio::sync::Semaphore;
 use tokio::time::sleep;
@@ -104,6 +104,13 @@ pub struct FileUploadStatus {
 pub type UploadQueue = Arc<Mutex<VecDeque<UploadItem>>>;
 pub type UploadConfigState = Arc<Mutex<UploadConfig>>;
 pub type UploadProgressState = Arc<Mutex<UploadProgress>>;
+// Latest status per relative path, in first-seen order so the oldest entries
+// can be evicted. Events emitted before the webview loads (e.g. during the
+// initial scan of a watch resumed at startup) are dropped by Tauri, so the
+// frontend replays this backlog on mount via get_upload_status_backlog.
+pub type UploadStatusLog = Arc<Mutex<Vec<FileUploadStatus>>>;
+
+const MAX_UPLOAD_STATUS_LOG: usize = 1000;
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct SessionContext {
@@ -200,9 +207,29 @@ pub fn emit_file_upload_status(
         status: status.to_string(),
         error,
     };
+    // Record before emitting so a frontend mounting concurrently sees the
+    // status either live or in the backlog, never neither
+    if let Some(log) = app_handle.try_state::<UploadStatusLog>() {
+        let mut log = log.lock();
+        if let Some(existing) = log.iter_mut().find(|s| s.relative_path == relative_path) {
+            *existing = upload_status.clone();
+        } else {
+            if log.len() >= MAX_UPLOAD_STATUS_LOG {
+                log.remove(0);
+            }
+            log.push(upload_status.clone());
+        }
+    }
     if let Err(e) = app_handle.emit("file_upload_status", &upload_status) {
         warn!("Failed to emit file upload status event: {e}");
     }
+}
+
+#[tauri::command]
+pub fn get_upload_status_backlog(
+    log: tauri::State<'_, UploadStatusLog>,
+) -> Result<Vec<FileUploadStatus>, String> {
+    Ok(log.lock().clone())
 }
 
 pub fn should_ignore_file(file_path: &str, ignored_patterns: &[String]) -> bool {

--- a/src-tauri/src/upload.rs
+++ b/src-tauri/src/upload.rs
@@ -110,7 +110,8 @@ pub type UploadProgressState = Arc<Mutex<UploadProgress>>;
 // frontend replays this backlog on mount via get_upload_status_backlog.
 pub type UploadStatusLog = Arc<Mutex<Vec<FileUploadStatus>>>;
 
-const MAX_UPLOAD_STATUS_LOG: usize = 1000;
+#[doc(hidden)]
+pub const MAX_UPLOAD_STATUS_LOG: usize = 1000;
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct SessionContext {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Labric Sync",
-  "version": "0.1.15",
+  "version": "0.1.17",
   "identifier": "co.labric.sync",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tests/event_backlog.rs
+++ b/src-tauri/tests/event_backlog.rs
@@ -1,0 +1,234 @@
+//! Tests for the event backlog that lets the frontend recover `file_change`
+//! and `file_upload_status` events emitted before the webview registered its
+//! listeners (Tauri drops emits that have no listener, so without the backlog
+//! the initial scan of a watch resumed at startup was invisible in the UI).
+//!
+//! Lives in an integration test target for the same reason as
+//! watch_supersede.rs: on Windows the test binary needs the Common Controls
+//! v6 manifest that build.rs injects via `rustc-link-arg-tests`.
+
+use std::collections::VecDeque;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use tauri::test::{mock_builder, mock_context, noop_assets, MockRuntime};
+use tauri::Manager;
+use uuid::Uuid;
+
+use labric_sync_lib::{
+    emit_file_upload_status, scan_folder_contents, start_watching_impl, FileChangeEvent,
+    FileChangeLog, UploadConfig, UploadConfigState, UploadQueue, UploadStatusLog, WatchGeneration,
+    WatchStartOutcome, WatchedFolderState, WatcherState, MAX_FILE_CHANGE_LOG,
+    MAX_UPLOAD_STATUS_LOG,
+};
+
+/// Mock app with both backlogs managed, the way run() manages them
+fn mock_app() -> tauri::App<MockRuntime> {
+    let file_change_log: FileChangeLog = Arc::new(Mutex::new(VecDeque::new()));
+    let upload_status_log: UploadStatusLog = Arc::new(Mutex::new(Vec::new()));
+    mock_builder()
+        // start_watching_impl persists the watched folder via the store plugin
+        .plugin(tauri_plugin_store::Builder::default().build())
+        .manage(file_change_log)
+        .manage(upload_status_log)
+        .build(mock_context(noop_assets()))
+        .expect("failed to build mock app")
+}
+
+/// Temp directory that cleans up on drop, without adding a tempfile dep
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new() -> Self {
+        let dir = std::env::temp_dir().join(format!("labric-sync-test-{}", Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        TempDir(dir)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+
+    fn path_str(&self) -> String {
+        self.0.to_string_lossy().to_string()
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+/// root/a.txt, root/sub/c.txt
+fn fixture_folder() -> TempDir {
+    let dir = TempDir::new();
+    fs::write(dir.path().join("a.txt"), "a").unwrap();
+    fs::create_dir(dir.path().join("sub")).unwrap();
+    fs::write(dir.path().join("sub").join("c.txt"), "c").unwrap();
+    dir
+}
+
+fn logged_names(app: &tauri::App<MockRuntime>) -> Vec<String> {
+    let log = app.state::<FileChangeLog>();
+    let mut names: Vec<String> = log
+        .lock()
+        .iter()
+        .map(|e| {
+            Path::new(&e.path)
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .to_string()
+        })
+        .collect();
+    names.sort();
+    names
+}
+
+#[test]
+fn scan_records_every_entry_in_the_backlog() {
+    let app = mock_app();
+    let dir = fixture_folder();
+
+    scan_folder_contents(&dir.path_str(), app.handle(), &|| false)
+        .expect("scan failed")
+        .expect("scan unexpectedly superseded");
+
+    // Directories are logged too -- the UI shows them in the change list
+    assert_eq!(logged_names(&app), ["a.txt", "c.txt", "sub"]);
+    let log = app.state::<FileChangeLog>();
+    assert!(log.lock().iter().all(|e| e.event_type == "initial"));
+}
+
+#[test]
+fn backlog_keeps_one_entry_per_path_across_rescans() {
+    let app = mock_app();
+    let dir = fixture_folder();
+
+    for _ in 0..2 {
+        scan_folder_contents(&dir.path_str(), app.handle(), &|| false)
+            .expect("scan failed")
+            .expect("scan unexpectedly superseded");
+    }
+
+    assert_eq!(logged_names(&app), ["a.txt", "c.txt", "sub"]);
+}
+
+#[test]
+fn backlog_is_capped_and_evicts_oldest() {
+    let app = mock_app();
+    let dir = TempDir::new();
+    // File names sort by creation order so the eviction order is predictable
+    for i in 0..MAX_FILE_CHANGE_LOG + 10 {
+        fs::write(dir.path().join(format!("f{i:04}.txt")), "x").unwrap();
+    }
+
+    scan_folder_contents(&dir.path_str(), app.handle(), &|| false)
+        .expect("scan failed")
+        .expect("scan unexpectedly superseded");
+
+    let log = app.state::<FileChangeLog>();
+    let log = log.lock();
+    assert_eq!(log.len(), MAX_FILE_CHANGE_LOG);
+    // The oldest entries were evicted from the front
+    assert!(!log.iter().any(|e| e.path.ends_with("f0000.txt")));
+    assert!(log.iter().any(|e| e.path.ends_with(&format!(
+        "f{:04}.txt",
+        MAX_FILE_CHANGE_LOG + 9
+    ))));
+}
+
+#[test]
+fn start_watching_clears_backlog_from_previous_folder() {
+    let app = mock_app();
+    let dir = fixture_folder();
+
+    {
+        let log = app.state::<FileChangeLog>();
+        log.lock().push_back(FileChangeEvent {
+            path: "stale-from-old-folder".to_string(),
+            event_type: "created".to_string(),
+            timestamp: 0,
+        });
+    }
+
+    let watcher_state: WatcherState = Arc::new(Mutex::new(None));
+    let watched_folder: WatchedFolderState = Arc::new(Mutex::new(None));
+    let generation: WatchGeneration = Arc::new(AtomicU64::new(1));
+    let queue: UploadQueue = Arc::new(Mutex::new(VecDeque::new()));
+    let config: UploadConfigState = Arc::new(Mutex::new(UploadConfig::default()));
+
+    let outcome = start_watching_impl(
+        dir.path_str(),
+        app.handle(),
+        &watcher_state,
+        &queue,
+        &config,
+        &watched_folder,
+        &generation,
+        1,
+    )
+    .expect("start failed");
+
+    assert!(matches!(outcome, WatchStartOutcome::Started));
+    let names = logged_names(&app);
+    assert!(!names.contains(&"stale-from-old-folder".to_string()));
+    assert_eq!(names, ["a.txt", "c.txt", "sub"]);
+}
+
+#[test]
+fn status_log_keeps_latest_status_per_path() {
+    let app = mock_app();
+
+    emit_file_upload_status("a.txt", "queued", None, app.handle());
+    emit_file_upload_status("b.txt", "queued", None, app.handle());
+    emit_file_upload_status("a.txt", "uploaded", None, app.handle());
+
+    let log = app.state::<UploadStatusLog>();
+    let log = log.lock();
+    assert_eq!(log.len(), 2);
+    // Updating a path keeps its original position (mirrors the frontend Map)
+    assert_eq!(log[0].relative_path, "a.txt");
+    assert_eq!(log[0].status, "uploaded");
+    assert_eq!(log[1].relative_path, "b.txt");
+    assert_eq!(log[1].status, "queued");
+}
+
+#[test]
+fn status_log_is_capped_and_evicts_oldest() {
+    let app = mock_app();
+
+    for i in 0..MAX_UPLOAD_STATUS_LOG + 5 {
+        emit_file_upload_status(&format!("f{i}.txt"), "queued", None, app.handle());
+    }
+
+    let log = app.state::<UploadStatusLog>();
+    let log = log.lock();
+    assert_eq!(log.len(), MAX_UPLOAD_STATUS_LOG);
+    assert_eq!(log[0].relative_path, "f5.txt");
+    assert_eq!(
+        log[log.len() - 1].relative_path,
+        format!("f{}.txt", MAX_UPLOAD_STATUS_LOG + 4)
+    );
+}
+
+#[test]
+fn recording_is_skipped_gracefully_when_logs_are_not_managed() {
+    // A mock app without the managed logs (like the watch_supersede tests)
+    let app = mock_builder()
+        .plugin(tauri_plugin_store::Builder::default().build())
+        .build(mock_context(noop_assets()))
+        .expect("failed to build mock app");
+    let dir = fixture_folder();
+
+    // Must not panic, and the scan must still succeed
+    let files = scan_folder_contents(&dir.path_str(), app.handle(), &|| false)
+        .expect("scan failed")
+        .expect("scan unexpectedly superseded");
+    assert_eq!(files.len(), 2);
+    emit_file_upload_status("a.txt", "queued", None, app.handle());
+}

--- a/src/components/simple.tsx
+++ b/src/components/simple.tsx
@@ -201,46 +201,6 @@ export default function Simple() {
       })
       .catch((err) => console.error("Failed to get watched folder:", err));
 
-    // Events emitted before this component mounted (e.g. the initial scan of
-    // a watch resumed at startup) were dropped, so backfill from the backend's
-    // backlog. The listeners above are already registered, so anything newer
-    // than these snapshots still arrives live; on conflicts the live entry wins.
-    invoke<FileChangeEvent[]>("get_file_change_backlog")
-      .then((backlog) => {
-        if (backlog.length === 0) return;
-        setFileChanges((prev) => {
-          const seen = new Set(prev.map((change) => change.path));
-          const merged = [
-            ...prev,
-            ...backlog.filter((change) => !seen.has(change.path)),
-          ];
-          return merged.slice(0, 500);
-        });
-      })
-      .catch((err) =>
-        console.error("Failed to load file change backlog:", err)
-      );
-    invoke<FileUploadStatus[]>("get_upload_status_backlog")
-      .then((backlog) => {
-        if (backlog.length === 0) return;
-        setUploadStatuses((prev) => {
-          const next = new Map<string, FileUploadStatus["status"]>();
-          for (const status of backlog) {
-            next.set(status.relative_path, status.status);
-          }
-          for (const [path, status] of prev) next.set(path, status);
-          while (next.size > 1000) {
-            const firstKey = next.keys().next().value;
-            if (firstKey === undefined) break;
-            next.delete(firstKey);
-          }
-          return next;
-        });
-      })
-      .catch((err) =>
-        console.error("Failed to load upload status backlog:", err)
-      );
-
     // Listen for file upload status events
     const unlistenUploadStatus = listen("file_upload_status", (event) => {
       console.log("file_upload_status", event);
@@ -256,6 +216,51 @@ export default function Simple() {
         return next;
       });
     });
+
+    // Events emitted before this component mounted (e.g. the initial scan of
+    // a watch resumed at startup) were dropped, so backfill from the backend's
+    // backlog. Wait for the listener registrations above to complete first, so
+    // every event is seen either live or in the snapshot; on conflicts the
+    // live entry wins.
+    Promise.all([unlistenFileChange, unlistenUploadStatus])
+      .catch(() => undefined) // backfill even if listener setup failed
+      .then(() => {
+        invoke<FileChangeEvent[]>("get_file_change_backlog")
+          .then((backlog) => {
+            if (backlog.length === 0) return;
+            setFileChanges((prev) => {
+              const seen = new Set(prev.map((change) => change.path));
+              const merged = [
+                ...prev,
+                ...backlog.filter((change) => !seen.has(change.path)),
+              ];
+              return merged.slice(0, 500);
+            });
+          })
+          .catch((err) =>
+            console.error("Failed to load file change backlog:", err)
+          );
+        invoke<FileUploadStatus[]>("get_upload_status_backlog")
+          .then((backlog) => {
+            if (backlog.length === 0) return;
+            setUploadStatuses((prev) => {
+              const next = new Map<string, FileUploadStatus["status"]>();
+              for (const status of backlog) {
+                next.set(status.relative_path, status.status);
+              }
+              for (const [path, status] of prev) next.set(path, status);
+              while (next.size > 1000) {
+                const firstKey = next.keys().next().value;
+                if (firstKey === undefined) break;
+                next.delete(firstKey);
+              }
+              return next;
+            });
+          })
+          .catch((err) =>
+            console.error("Failed to load upload status backlog:", err)
+          );
+      });
 
     return () => {
       unlistenFileChange.then((fn) => fn());

--- a/src/components/simple.tsx
+++ b/src/components/simple.tsx
@@ -201,6 +201,46 @@ export default function Simple() {
       })
       .catch((err) => console.error("Failed to get watched folder:", err));
 
+    // Events emitted before this component mounted (e.g. the initial scan of
+    // a watch resumed at startup) were dropped, so backfill from the backend's
+    // backlog. The listeners above are already registered, so anything newer
+    // than these snapshots still arrives live; on conflicts the live entry wins.
+    invoke<FileChangeEvent[]>("get_file_change_backlog")
+      .then((backlog) => {
+        if (backlog.length === 0) return;
+        setFileChanges((prev) => {
+          const seen = new Set(prev.map((change) => change.path));
+          const merged = [
+            ...prev,
+            ...backlog.filter((change) => !seen.has(change.path)),
+          ];
+          return merged.slice(0, 500);
+        });
+      })
+      .catch((err) =>
+        console.error("Failed to load file change backlog:", err)
+      );
+    invoke<FileUploadStatus[]>("get_upload_status_backlog")
+      .then((backlog) => {
+        if (backlog.length === 0) return;
+        setUploadStatuses((prev) => {
+          const next = new Map<string, FileUploadStatus["status"]>();
+          for (const status of backlog) {
+            next.set(status.relative_path, status.status);
+          }
+          for (const [path, status] of prev) next.set(path, status);
+          while (next.size > 1000) {
+            const firstKey = next.keys().next().value;
+            if (firstKey === undefined) break;
+            next.delete(firstKey);
+          }
+          return next;
+        });
+      })
+      .catch((err) =>
+        console.error("Failed to load upload status backlog:", err)
+      );
+
     // Listen for file upload status events
     const unlistenUploadStatus = listen("file_upload_status", (event) => {
       console.log("file_upload_status", event);


### PR DESCRIPTION
## Problem

When the app restarts and resumes watching, the initial folder scan runs during `setup()` — before the webview has mounted and registered its event listeners. Tauri drops emits that have no listener, and the frontend's file list is built purely from live `file_change` events, so after a restart the UI showed no files even though the scan ran and uploads proceeded. Live watch events still worked, which made it look like only the "old" files were missing. Per-file upload status icons were lost the same way. (The "ignore existing files" setting was unrelated — it only gates upload queueing.)

## Fix

The backend now records what it emits, and the frontend replays the backlog on mount:

- `FileChangeLog` managed state: latest event per path, capped at 500 (matching the frontend list cap). Recorded by `record_and_emit_file_change` at both emit sites (watcher callback and initial scan), exposed via `get_file_change_backlog`, cleared on `stop_watching` and when a new watch starts — mirroring when the frontend clears its list.
- `UploadStatusLog` managed state: latest status per relative path, capped at 1000. Recorded inside `emit_file_upload_status`, exposed via `get_upload_status_backlog`.
- Recording happens **before** emitting, and the frontend registers listeners **before** pulling the backlogs, so a frontend mounting mid-scan sees every event either live or in the snapshot — never neither. Live entries win merge conflicts.

Bumps version to 0.1.17 (0.1.16 is taken by #24).

## Verification

- `cargo check` and `cargo clippy` clean, `tsc --noEmit` clean
- Not verified by launching the app: dev shares the installed app's store/identifier and would trigger real uploads. Manual test: watch a folder, quit, reopen — existing files should populate the list with status icons.

## Note

Conflicts with #24, which rewrites the same functions (`capture_initial_contents` → `scan_folder_contents`, runtime-generic signatures). Suggested order: merge #24 first; this branch then needs a rebase adapting the helpers to be generic over `tauri::Runtime`.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>