### PR TITLE
Upgrade actions to Node 24 releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,16 +23,16 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: lts/*
           cache: pnpm

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "labric-sync",
   "private": true,
-  "version": "0.1.17",
+  "version": "0.1.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2445,7 +2445,7 @@ dependencies = [
 
 [[package]]
 name = "labric-sync"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "base64 0.21.7",
  "bytes",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "labric-sync"
-version = "0.1.17"
+version = "0.1.18"
 description = "Labric Sync desktop app"
 authors = ["Labric"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Labric Sync",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "identifier": "co.labric.sync",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Problem

Every workflow run warns:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4, pnpm/action-setup@v4.

## Change

Bump each to its current major, all of which target node24:

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-node` | v4 | v7 |
| `pnpm/action-setup` | v4 | v6 |

Compatibility, checked against our workflows:
- **checkout v7** blocks fork-PR checkout on `pull_request_target`/`workflow_run` triggers — our review workflow uses plain `pull_request`, so unaffected. v6's credential-persistence change and v7's ESM migration don't touch our usage.
- **setup-node v7** still supports the explicit `cache: pnpm` + `cache-dependency-path` inputs we use. The v5+ automatic-caching feature keys off a `packageManager` field in package.json, which we don't have — no behavior change.
- **pnpm/action-setup v6** adds pnpm 11 support on top of v5's node24 move; our pinned `version: 10` input is unchanged.

`tauri-apps/tauri-action`, `dtolnay/rust-toolchain`, `digicert/ssm-code-signing`, and `anthropics/claude-code-action` were not named in the warning and are left as-is.

Bumps version to 0.1.18.

The claude-review check on this PR exercises the upgraded checkout; the build workflow only runs on push to main, so the first release build after merge confirms the rest.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>