### PR TITLE
Update README project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ src/                        # React frontend
       route.tsx             # Auth guard layout
       dashboard.tsx         # Main file watcher dashboard
   components/               # UI components (shadcn/ui + custom)
-  hooks/                    # useUploadManager, useHeartbeat, useAppUpdater
+  hooks/                    # useUploadManager, useHeartbeat, useAppUpdater, use-session-context
   lib/                      # Tauri store wrapper, utils
   types/                    # TypeScript type definitions
 
@@ -88,6 +88,8 @@ src-tauri/                  # Rust backend
     lib.rs                  # App setup, Tauri commands, file watcher
     upload.rs               # Upload queue processor
     heartbeat.rs            # Heartbeat service
+    diagnostics.rs          # Network diagnostics (connectivity checks)
+    http_client.rs          # Shared HTTP client + response helpers
   tauri.conf.json           # Tauri app configuration
   Cargo.toml                # Rust dependencies
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "labric-sync",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2445,7 +2445,7 @@ dependencies = [
 
 [[package]]
 name = "labric-sync"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.21.7",
  "bytes",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "labric-sync"
-version = "0.2.0"
+version = "0.2.1"
 description = "Labric Sync desktop app"
 authors = ["Labric"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Labric Sync",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "co.labric.sync",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Audited the README against the current codebase. Almost everything was accurate; two spots had drifted:

- `src-tauri/src/` structure was missing `diagnostics.rs` (network diagnostics) and `http_client.rs` (shared HTTP client)
- `src/hooks/` listing was missing `use-session-context`

Verified accurate as-is: features list (notify watcher, CRC32C, 30s heartbeat, glob ignore patterns, updater), tech stack versions (React 19, Vite 8, Tailwind v4), dev port 1420, `pnpm types` endpoint, pairing flow endpoints (`get-code`, `poll-pairing`), CI/CD description, and `VITE_SERVER_URL`.

Also bumps version to 0.2.1 per repo convention. Note: merging will draft an `app-v0.2.1` release — leave it unpublished until the 0.2.0 auto-update test is done, since the updater only sees published releases.