### PR TITLE
Add Rust build caching to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,11 @@ jobs:
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
       - name: Linux deps (ubuntu only)
         if: matrix.platform == 'ubuntu-22.04'
         run: |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "labric-sync",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "labric-sync"
-version = "0.2.1"
+version = "0.2.2"
 description = "Labric Sync desktop app"
 authors = ["Labric"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Labric Sync",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "co.labric.sync",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Adds Swatinem/rust-cache@v2 to the publish workflow and bumps version to 0.2.2. First post-merge build is still cold; speedup starts on the second build.